### PR TITLE
Fixed scrollbar clipping in Miz file editor

### DIFF
--- a/packages/miz-js/src/ace.css
+++ b/packages/miz-js/src/ace.css
@@ -2,7 +2,7 @@
 	height: calc(100% - 10px);
   margin: 0;
 	/* min-width: calc(30% - 1rem); */
-  overflow: hidden;
-  min-width: 100%;
+  overflow: auto;
+  min-width: fit-content;
   /* max-width: 80%; */
 }

--- a/packages/miz-js/src/miz-manager.css
+++ b/packages/miz-js/src/miz-manager.css
@@ -25,6 +25,7 @@
 
 #save-editor {
   float: right;
+  
   background-color: #23313f;
   color: #89bed7;
   border: 1px solid #89bed7;
@@ -178,6 +179,7 @@ summary {
 
 .tree, .listing, .previews {
 	padding: 5px;
+	overflow: auto;
 	height: calc(100% - 10px);
 	margin: 0;
   min-width: 200px;


### PR DESCRIPTION
As outlined in https://discord.com/channels/1066414751510433794/1066832510501273610/1092968517395021944, there were some issues in the mission file editor where the scrollbar on the right was clipping into the outer container. I changed some of the width and overflow properties to fix this. From my testing, no other functionality was adversely affected across various miz files, images, etc. Let me know if there is anything I can change.